### PR TITLE
Fix issue 128 so that System.printInfo correctly handles '#'

### DIFF
--- a/platform/emulator/foreign.cc
+++ b/platform/emulator/foreign.cc
@@ -1366,8 +1366,13 @@ char* OZ_vsToC(OZ_Term t,int*n)
     return null;
   }
   else if (OZ_isAtom(t)) {
+    int len;
     s = dropConst(OZ_atomToC(t));
-    if (n!=0) *n = strlen(s);
+    len = strlen(s);
+    if (len == 1 && s[0] == '#') {
+      s = OZ_virtualStringToC(t, &len);
+    }
+    if (n!=0) *n = len;
   } else {
     // Do not use bytestring directly, they are not null terminated! CS
     s = OZ_virtualStringToC(t,n);


### PR DESCRIPTION
This is my attempt at fixing #128. The fix is based on the feedback from [this reply](http://lists.gforge.info.ucl.ac.be/pipermail/mozart-hackers/2011/003248.html)  to my [query on the mailing list](http://lists.gforge.info.ucl.ac.be/pipermail/mozart-hackers/2011/003235.html).

For the fix I change printInfo so that if it is an atom that is passed as an argument there is a check explicitly for '#'. If it is this atom then the the routine to convert a virtual string to a string is used instead.
