### PR TITLE
Tcl_GetStringResult should be used instead of interp->result

### DIFF
--- a/platform/wish/unixMain.cc
+++ b/platform/wish/unixMain.cc
@@ -1,4 +1,4 @@
-/* 
+/*
  * main.c --
  *
  *	This file contains the main program for "ozwish", a windowing
@@ -21,7 +21,7 @@
  * software and its documentation for any purpose, provided that the
  * above copyright notice and the following two paragraphs appear in
  * all copies of this software.
- * 
+ *
  * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
  * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT
  * OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF
@@ -143,7 +143,8 @@ static void		StdinProc _ANSI_ARGS_((ClientData clientData,
 int
 main(int argc, char **argv)
 {
-    char *args, *p, *msg;
+    char *args, *p;
+    const char *msg;
     char buf[20];
     int code;
 
@@ -157,7 +158,7 @@ main(int argc, char **argv)
 
     if (Tk_ParseArgv(interp, (Tk_Window) NULL, &argc, CONST_CAST(CONST_FOR_ARGV char**,argv), argTable, 0)
 	    != TCL_OK) {
-	fprintf(stdout, "w %s\n.\n", interp->result);
+	fprintf(stdout, "w %s\n.\n", Tcl_GetStringResult(interp));
 	fflush(stdout); /* added mm */
 	exit(1);
     }
@@ -192,7 +193,7 @@ main(int argc, char **argv)
 #ifdef RS
     mainWindow = Tk_CreateMainWindow(interp, display, name, "Tk");
     if (mainWindow == NULL) {
-	fprintf(stdout, "w %s\n.\n", interp->result);
+	fprintf(stdout, "w %s\n.\n", Tcl_GetStringResult(interp));
 	fprintf(stdout, "s stop\n");
 	fflush(stdout); /* added mm */
 	exit(1);
@@ -232,7 +233,7 @@ main(int argc, char **argv)
      */
 
     if (Tcl_AppInit(interp) != TCL_OK) {
-	fprintf(stdout, "w Tcl_AppInit failed: %s\n.\n", interp->result);
+	fprintf(stdout, "w Tcl_AppInit failed: %s\n.\n", Tcl_GetStringResult(interp));
 	fflush(stdout); /* added mm */
     }
 
@@ -243,7 +244,7 @@ main(int argc, char **argv)
     if (geometry != NULL) {
 	code = Tcl_VarEval(interp, "wm geometry . ", geometry, (char *) NULL);
 	if (code != TCL_OK) {
-	    fprintf(stdout, "w %s\n.\n", interp->result);
+	    fprintf(stdout, "w %s\n.\n", Tcl_GetStringResult(interp));
 	    fflush(stdout); /* added mm */
 	}
     }
@@ -251,7 +252,7 @@ main(int argc, char **argv)
     /* mm: do not show the main window */
     code = Tcl_Eval(interp, "wm withdraw . ");
     if (code != TCL_OK) {
-      fprintf(stdout, "w %s\n.\n", interp->result);
+      fprintf(stdout, "w %s\n.\n", Tcl_GetStringResult(interp));
       fflush(stdout); /* added mm */
     }
 
@@ -301,7 +302,7 @@ main(int argc, char **argv)
 error:
     msg = CONST_CAST(char*,Tcl_GetVar(interp, CONST_CAST(CONST char*,"errorInfo"), TCL_GLOBAL_ONLY));
     if (msg == NULL) {
-	msg = interp->result;
+	msg = Tcl_GetStringResult(interp);
     }
     fprintf(stdout, "w %s\n.\n", msg);
     fflush(stdout);  /* added mm */
@@ -380,10 +381,10 @@ StdinProc(ClientData clientData, int mask)
     Tk_CreateFileHandler(0, 0, StdinProc, (ClientData) 0);
     code = Tcl_Eval(interp, cmd);
     Tk_CreateFileHandler(0, TK_READABLE, StdinProc, (ClientData) 0);
-    if (*interp->result != 0) {
+    if (*Tcl_GetStringResult(interp) != 0) {
 	if ((code != TCL_OK) || (tty)) {
 	  fprintf(stdout,"w --- %s", cmd);
-	  fprintf(stdout,"---  %s\n---\n.\n", interp->result);
+	  fprintf(stdout,"---  %s\n---\n.\n", Tcl_GetStringResult(interp));
 	  fflush(stdout); /* by mm */
 	}
     }
@@ -432,7 +433,7 @@ Prompt(Tcl_Interp *interp, int partial)
 	if (code != TCL_OK) {
 	    Tcl_AddErrorInfo(interp,
 		    "\n    (script that generates prompt)");
-	    fprintf(stdout, "w %s\n.\n", interp->result);
+	    fprintf(stdout, "w %s\n.\n", Tcl_GetStringResult(interp));
 	    fflush(stdout); /* added mm */
 	    goto defaultPrompt;
 	}

--- a/platform/wish/winMain.cc
+++ b/platform/wish/winMain.cc
@@ -1,5 +1,5 @@
 
-/* 
+/*
  * winMain.c --
  *
  *      Main entry point for wish and other Tk-based applications.
@@ -67,20 +67,20 @@ PutsCmd(ClientData clientData, Tcl_Interp *inter, int argc, char **argv)
     newline = 0;
     i++;
   }
-  
+
   if ((i < (argc-3)) || (i >= argc)) {
     Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0],
                      " ?-nonewline? ?fileId? string\"", (char *) NULL);
     return TCL_ERROR;
   }
-  
+
   if (i != (argc-1))
     i++;
-  
+
   sendToEngine(argv[i]);
   if (newline)
     sendToEngine("\n");
-  
+
   DebugCode(fprintf(dbgout,"********puts(%d):\n%s\n",inter,argv[i]); fflush(dbgout));
   return TCL_OK;
 }
@@ -151,9 +151,9 @@ void readHandler(ClientData clientData, int mask)
   // that the I/O manager calls a readHandler exactly once for each
   // channel. That is, it cannot happen that two 'readHandlers' are
   // started simultaneously.
-  if (tkLock == 1) 
+  if (tkLock == 1)
     return;
-  else 
+  else
     tkLock = 1;
   static int bufSize  = 1000;
   static char *buffer = NULL;
@@ -162,12 +162,12 @@ void readHandler(ClientData clientData, int mask)
   }
 
   static int used = 0;
-  
+
   if (used>=bufSize) {
     bufSize *= 2;
     buffer = (char *) realloc(buffer,bufSize+1);
     if (buffer==0)
-      WishPanic("realloc of buffer failed");    
+      WishPanic("realloc of buffer failed");
   }
 
 
@@ -175,11 +175,11 @@ void readHandler(ClientData clientData, int mask)
   int count = Tcl_Read(in,buffer+used,bufSize-used);
 
   if (count<0) {
-    WishPanic("Connection to engine lost: %d, %d, %d", 
+    WishPanic("Connection to engine lost: %d, %d, %d",
               count, in, Tcl_GetErrno());
   }
 
-  
+
   if (count==0) {
     if (Tcl_Eof(in)) {
       WishPanic("Eof on input stream");
@@ -191,9 +191,9 @@ void readHandler(ClientData clientData, int mask)
 
   used += count;
   buffer[used] = 0;
-  
+
   DebugCode(fprintf(dbgin,"\n### read done: %d\n%s\n",count,buffer); fflush(dbgin));
-  
+
   if ((buffer[used-1] != '\n') && (buffer[used-1] != ';') ||
       !Tcl_CommandComplete(buffer) ||
       used >=2 && buffer[used-2] == '\\') {
@@ -205,14 +205,14 @@ void readHandler(ClientData clientData, int mask)
   int code = Tcl_GlobalEval(interp, buffer);
   if (code != TCL_OK) {
     char buf[1000];
-    DebugCode(fprintf(dbgin,"### Error(%d):  %s\n", code,interp->result);
+    DebugCode(fprintf(dbgin,"### Error(%d):  %s\n", code,Tcl_GetStringResult(interp));
               fflush(dbgin));
-    sprintf(buf,"w --- %s---  %s\n---\n.\n", buffer,interp->result);
+    sprintf(buf,"w --- %s---  %s\n---\n.\n", buffer,Tcl_GetStringResult(interp));
     sendToEngine(buf);
   }
 
   used = 0;
-  // dragan: no race conditions here either: 
+  // dragan: no race conditions here either:
   tkLock = 0;
 }
 
@@ -248,7 +248,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdLine, int nCm
      */
     if (Tcl_Init(interp) == TCL_ERROR ||
         Tk_Init(interp) == TCL_ERROR) {
-      WishPanic("Tcl_Init failed: %s\n", interp->result);
+      WishPanic("Tcl_Init failed: %s\n", Tcl_GetStringResult(interp));
     }
 
     Tcl_ResetResult(interp);
@@ -279,7 +279,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdLine, int nCm
     code = Tcl_GlobalEval(interp, "wm withdraw . ");
     if (code != TCL_OK) {
       char buf[1000];
-      sprintf(buf,"w %s\n.\n", interp->result);
+      sprintf(buf,"w %s\n.\n", Tcl_GetStringResult(interp));
       sendToEngine(buf);
     }
 
@@ -316,7 +316,7 @@ WishPanic TCL_VARARGS_DEF(const char *,arg1)
   const char *format = TCL_VARARGS_START(const char *,arg1,argList);
   char buf[1024];
   vsprintf(buf, format, argList);
-  
+
   MessageBeep(MB_ICONEXCLAMATION);
   MessageBox(NULL, buf, "Fatal Error in Wish",
              MB_ICONSTOP | MB_OK | MB_TASKMODAL | MB_SETFOREGROUND);
@@ -330,7 +330,7 @@ WishInfo TCL_VARARGS_DEF(char *,arg1)
   char *format = TCL_VARARGS_START(char *,arg1,argList);
   char buf[1024];
   vsprintf(buf, format, argList);
-  
+
   MessageBox(NULL, buf, "Fatal Error in Wish",
              MB_ICONSTOP | MB_OK | MB_TASKMODAL | MB_SETFOREGROUND);
 }


### PR DESCRIPTION
Hey,

Direct access to interp->result has been deprecated and since then
removed (it can be re-enabled by defining USE_INTERP_RESULT, but documentation
recommends against it).

(I did not actually try to build the windows version, but it looks like it should still behave as before.)
