### PR TITLE
Fix ambiguous use of 'mo' in Tk in mozart-1-3-x branch

### DIFF
--- a/share/tools/explorer/layout-nodes.oz
+++ b/share/tools/explorer/layout-nodes.oz
@@ -183,7 +183,7 @@ local
 	 LayoutLeaf,Layout(_ 0)
 	 LayoutLeaf,Adjust(Break RootX 0 RootY Scale Font)
 	 %% move away root link
-	 {Canvas tk(mo @item 0 ~VerSpaceF * MaxScale)}
+	 {Canvas tk(move @item 0 ~VerSpaceF * MaxScale)}
 	 {Canvas bounding(~HalfHorSpaceI HalfHorSpaceI VerSpaceI)}
       end
 
@@ -236,7 +236,7 @@ local
       in
 	 {Canvas {GetBoundingBox Shape}}
 	 LayoutNode,Adjust(Break RootX 0 RootY Scale Font)
-	 {Canvas tk(mo @item 0 ~VerSpaceF * MaxScale)}
+	 {Canvas tk(move @item 0 ~VerSpaceF * MaxScale)}
       end
 
       meth !Layout(?Shape Offset)

--- a/share/tools/explorer/tk-nodes.oz
+++ b/share/tools/explorer/tk-nodes.oz
@@ -128,9 +128,9 @@ local
 		       Scale*{IntToFloat (MyY - UpperSpaceI)}
 		       Scale*{IntToFloat MyX}
 		       Scale*{IntToFloat (MyY - CircleWidthI)})}
-	    {Canvas tk(mo NodeItem Scale*{IntToFloat MyByX} 0)}
+	    {Canvas tk(move NodeItem Scale*{IntToFloat MyByX} 0)}
 	    if Number\=0 then
-	       {Canvas tk(mo n#Number Scale*{IntToFloat MyByX} 0)}
+	       {Canvas tk(move n#Number Scale*{IntToFloat MyByX} 0)}
 	    end
 	    if @toDo\=nil orelse @isHidden then skip else
 	       {Canvas tk(itemco NodeItem
@@ -447,7 +447,7 @@ local
 		       Scale*{IntToFloat (MyY - UpperSpaceI)}
 		       Scale*{IntToFloat MyX}
 		       Scale*{IntToFloat (MyY - RectangleWidthI)})}
-	    {Canvas tk(mo Item+1 Scale*{IntToFloat MyByX} 0)}
+	    {Canvas tk(move Item+1 Scale*{IntToFloat MyByX} 0)}
 	 end
       
       end
@@ -525,9 +525,9 @@ local
 			  Scale*{IntToFloat (MyY - UpperSpaceI)}
 			  Scale*{IntToFloat MyX}
 			  Scale*{IntToFloat (MyY - RhombeWidthI)})}
-	       {Canvas tk(mo Item+1 Scale*{IntToFloat MyByX} 0)}
+	       {Canvas tk(move Item+1 Scale*{IntToFloat MyByX} 0)}
 	       if Number\=0 then
-		  {Canvas tk(mo n#Number Scale*{IntToFloat MyByX} 0)}
+		  {Canvas tk(move n#Number Scale*{IntToFloat MyByX} 0)}
 	       end
 	    end
 	    


### PR DESCRIPTION
The Explorer doesn't work due to what is I assume Tk changes. It uses 'mo' command which is ambiguous with 'move' and 'moveall'. This change makes it explicit.

This is a cherry pick of the master branch fix for branch mozart-1-3-x.