### PR TITLE
Fix README links for domain change

### DIFF
--- a/README
+++ b/README
@@ -1,10 +1,11 @@
 For more information on Oz and Mozart see
 
-	http://www.mozart-oz.org
+	https://mozart.github.io/
 
-We would appreciate if you could send E-mail to
-        
-	download@mozart-oz.org
+We would appreciate if you could send E-mail to the
+mozart-users mailing list:
+
+        https://groups.google.com/forum/#!forum/mozart-users
 
 with some brief information for what you plan to use Mozart.
 
@@ -29,4 +30,4 @@ Change the prefix path and `OZHOME` to where you want it installed. Run `oz` to 
 Installation.
 -------------
 
-Please refer to this website for more detail : http://www.mozart-oz.org/documentation/install/index.html
+Please refer to this website for more detail : https://mozart.github.io/mozart-v1/doc-1.4.0/install/index.html


### PR DESCRIPTION
Changes domain in README to point to current Mozart website and documentation. There's no Mozart 1.3 specific documentation so I point it to the 1.4 documentation.