### PR TITLE
Fix build segfault when compiling with GCC 6 in mozart-1-3-x

### DIFF
--- a/platform/emulator/cac.cc
+++ b/platform/emulator/cac.cc
@@ -1438,7 +1438,9 @@ void ConstTerm::_cacConstRecurse(void) {
 #ifdef G_COLLECT
 	gCollectPendThreadEmul(&(ll->pending));
 #endif
-	ll->setLocker(SuspToThread(ll->getLocker()->_cacSuspendable()));
+	if (ll->getLocker()) {
+		ll->setLocker(SuspToThread(ll->getLocker()->_cacSuspendable()));
+	}
 	maybeGCForFailure(t);
 	break;
       } 


### PR DESCRIPTION
When building with GCC 6 the compilation crashes on the first
attempt to build Error.oz using the newly compiled runtime.

The crash occurs in platform/emulator/cac.cc line 1441:

    ll->setLocker(SuspToThread(ll->getLocker()->_cacSuspendable()));

ll->getLocker() is returning NULL. In the master branch this file
has changed somewhat but the equivalent line, line 1415, is:

     if (ll->locker != 0)
         oz_cacTerm(ll->locker, ll->locker);

Note the NULL check. The fix here is to add that NULL check and
compilation proceeds normally.

Why the behaviour is different with gcc 6 vs gcc 4.9 I don't know.

There are other issues with GCC 6, even with this fix. The following
test hangs on guards_g29:

    cd share/test && make boot--oztest boot-check

This test also hangs on master compiled with GCC 6 so I don't think
this fix adds any additional regression that master doesn't already
have.