### PR TITLE
Add call to interactive in oz-attach elisp to get ozcar working

### DIFF
--- a/share/elisp/mozart.el.in
+++ b/share/elisp/mozart.el.in
@@ -1120,6 +1120,7 @@ With C-u C-u as prefix argument, send it a SIGKILL instead."
 	(message "Oz started."))))
 
 (defun oz-attach ()
+  (interactive)
   (let (host port)
     (cond ((>= (length command-line-args-left) 1)
 	   (setq host *oz-default-host*


### PR DESCRIPTION
Invoking 'ozd -E' from the OS shell gives an error when Emacs starts about oz-attach. The fix is to make the elisp function interactive.