### PR TITLE
Gcc optimization fix

### DIFF
--- a/README
+++ b/README
@@ -20,14 +20,15 @@ sudo packer -S mozart-git
 Building mozart for Ubuntu/Debian (x64).
 ----------------------------------
 $ sudo apt-get install emacs flex bison tk-dev build-essential g++-multilib zlib1g-dev:i386 libgmp-dev:i386
-$ mkdir -p ~/dev/mozart
-$ cd ~/dev/mozart
-$ git clone git://github.com/mozart/mozart.git
-$ ./configure --prefix=/home/<username>/oz --disable-contrib-gdbm --enable-modules-static
+$ git clone https://github.com/mozart/mozart
+$ mkdir build
+$ cd build
+$ ../mozart/configure --prefix=/home/$USER/oz --disable-contrib-gdbm 
 $ make && make install
-amend and append the below to your ~/.profile file
-export OZHOME=/home/<username>/oz
-export PATH=$PATH:$OZHOME/bin
+$ export OZHOME=/home/$USER/oz
+$ export PATH=$PATH:$OZHOME/bin
+
+Change the prefix path and `OZHOME` to where you want it installed. Run `oz` to start the IDE.
 
 Building mozart for OS X
 ------------------------

--- a/configure
+++ b/configure
@@ -1786,7 +1786,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 

--- a/contrib/configure
+++ b/contrib/configure
@@ -2011,7 +2011,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 

--- a/doc/configure
+++ b/doc/configure
@@ -2309,7 +2309,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 

--- a/platform/configure
+++ b/platform/configure
@@ -1734,7 +1734,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 

--- a/platform/emulator/configure
+++ b/platform/emulator/configure
@@ -3689,7 +3689,7 @@ fi
 	;;
     linux-x86_64_32)
         oz_opt="-O3 -pipe -fno-strict-aliasing"
-	oz_om="-m32 -march=i686 -mtune=generic -fomit-frame-pointer"
+	oz_om="-m32 -march=i686 -mtune=generic -fomit-frame-pointer -fno-tree-vrp"
         oz_copt_debug="-m32 -g3 -DINTERFACE -fno-inline -fno-default-inline -fno-inline-functions"
 	EMULATE_CXXFLAGS=-finline-limit=500
         ;;

--- a/platform/emulator/configure.in
+++ b/platform/emulator/configure.in
@@ -306,7 +306,7 @@ if test "${GXX}" = yes; then
 	;;
     linux-x86_64_32)
         oz_opt="-O3 -pipe -fno-strict-aliasing"
-	oz_om="-m32 -march=i686 -mtune=generic -fomit-frame-pointer"
+	oz_om="-m32 -march=i686 -mtune=generic -fomit-frame-pointer -fno-tree-vrp"
         oz_copt_debug="-m32 -g3 -DINTERFACE -fno-inline -fno-default-inline -fno-inline-functions"
 	EMULATE_CXXFLAGS=-finline-limit=500
         ;;

--- a/platform/tools/configure
+++ b/platform/tools/configure
@@ -1721,7 +1721,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 

--- a/platform/tools/gump/configure
+++ b/platform/tools/gump/configure
@@ -2922,7 +2922,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 


### PR DESCRIPTION
The 'tree-vrp' optimization stage causes the mozart emulator to segfault during the build process if using recent gcc versions. Disable the optimization until we find what code is triggering the issue. This fixes an issue raised in the mozart-users mailing list.

Update the README for Ubuntu build instructions.
