### PR TITLE
Gcc optimization fix for 1.3.x branch

### DIFF
--- a/configure
+++ b/configure
@@ -1772,7 +1772,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 

--- a/contrib/configure
+++ b/contrib/configure
@@ -1997,7 +1997,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 

--- a/doc/configure
+++ b/doc/configure
@@ -2295,7 +2295,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 

--- a/platform/configure
+++ b/platform/configure
@@ -1714,7 +1714,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 

--- a/platform/emulator/configure
+++ b/platform/emulator/configure
@@ -3673,7 +3673,7 @@ fi
 	;;
     linux-x86_64_32)
         oz_opt="-O3 -pipe -fno-strict-aliasing"
-	oz_om="-m32 -march=i686 -mtune=generic -fomit-frame-pointer"
+	oz_om="-m32 -march=i686 -mtune=generic -fomit-frame-pointer -fno-tree-vrp"
         oz_copt_debug="-m32 -g3 -DINTERFACE -fno-inline -fno-default-inline -fno-inline-functions"
 	EMULATE_CXXFLAGS=-finline-limit=500
         ;;

--- a/platform/emulator/configure.in
+++ b/platform/emulator/configure.in
@@ -303,7 +303,7 @@ if test "${GXX}" = yes; then
 	;;
     linux-x86_64_32)
         oz_opt="-O3 -pipe -fno-strict-aliasing"
-	oz_om="-m32 -march=i686 -mtune=generic -fomit-frame-pointer"
+	oz_om="-m32 -march=i686 -mtune=generic -fomit-frame-pointer -fno-tree-vrp"
         oz_copt_debug="-m32 -g3 -DINTERFACE -fno-inline -fno-default-inline -fno-inline-functions"
 	EMULATE_CXXFLAGS=-finline-limit=500
         ;;

--- a/platform/tools/configure
+++ b/platform/tools/configure
@@ -1707,7 +1707,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 

--- a/platform/tools/gump/configure
+++ b/platform/tools/gump/configure
@@ -2908,7 +2908,7 @@ if test "$no_recursion" != yes; then
       fi
     fi
 
-    cd $ac_popdir
+    cd "$ac_popdir"
   done
 fi
 


### PR DESCRIPTION
The 'tree-vrp' optimization stage causes the mozart emulator to segfault during the build process if using recent gcc versions. Disable the optimization until we find what code is triggering the issue. This fixes an issue raised in the mozart-users mailing list.

This is a backport of a fix for Mozart 1.4.x that I did a pull request for a few minutes ago.
