### PR TITLE
Compiler warning fixes for Mozart 1.4.x

### DIFF
--- a/platform/emulator/configure
+++ b/platform/emulator/configure
@@ -3599,7 +3599,7 @@ fi
 	    -Wcast-qual -Wconversion -Wimplicit-function-dec -Wimplicit-int -Wmissing-braces \
 	    -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wparentheses \
 	    -Wsequence-point -Wpointer-arith -Wno-sign-compare -Wunknown-pragmas \
-	    -Wstrict-prototypes -Wno-write-strings -Wreturn-type -Wsynth -Wno-reorder \
+	    -Wstrict-prototypes -Wreturn-type -Wsynth -Wno-reorder \
 	    -Wno-uninitialized -Wunreachable-code -Wno-unused -Winline -Wdeprecated"
 	;;
 	esac

--- a/platform/emulator/configure.in
+++ b/platform/emulator/configure.in
@@ -216,7 +216,7 @@ if test "${GXX}" = yes; then
 	    -Wcast-qual -Wconversion -Wimplicit-function-dec -Wimplicit-int -Wmissing-braces \
 	    -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wparentheses \
 	    -Wsequence-point -Wpointer-arith -Wno-sign-compare -Wunknown-pragmas \
-	    -Wstrict-prototypes -Wno-write-strings -Wreturn-type -Wsynth -Wno-reorder \
+	    -Wstrict-prototypes -Wreturn-type -Wsynth -Wno-reorder \
 	    -Wno-uninitialized -Wunreachable-code -Wno-unused -Winline -Wdeprecated"
 	;;
 	esac

--- a/platform/emulator/foreign.cc
+++ b/platform/emulator/foreign.cc
@@ -1361,7 +1361,7 @@ char* OZ_vsToC(OZ_Term t,int*n)
 {
   char * s;
   if (OZ_isNil(t)) {
-    static char *null = "";
+    static char *null = strdup("");
     if (n!=0) *n = 0;
     return null;
   }

--- a/platform/emulator/libfd/sum.cc
+++ b/platform/emulator/libfd/sum.cc
@@ -38,7 +38,7 @@
 
 OZ_BI_define(fdp_sum, 3, 0)
 {
-  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_FD","OZ_EM_LIT","OZ_EM_FD);
+  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_FD "," OZ_EM_LIT "," OZ_EM_FD);
 
   PropagatorExpect pe;
 
@@ -82,8 +82,8 @@ template unsigned int make_lessEqOffsetN<unsigned int, PropagatorExpect, unsigne
 
 OZ_BI_define(fdp_sumC, 4, 0)
 {
-  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_INT","OZ_EM_VECT OZ_EM_FD","OZ_EM_LIT
-		   ","OZ_EM_FD);
+  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_INT "," OZ_EM_VECT OZ_EM_FD "," OZ_EM_LIT
+		   "," OZ_EM_FD);
 
   PropagatorExpect pe;
 
@@ -134,8 +134,8 @@ OZ_BI_end
 
 OZ_BI_define(fdp_sumCN, 4, 0)
 {
-  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_INT","OZ_EM_VECT OZ_EM_VECT OZ_EM_FD
-		   ","OZ_EM_LIT","OZ_EM_FD);
+  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_INT "," OZ_EM_VECT OZ_EM_VECT OZ_EM_FD
+		   "," OZ_EM_LIT "," OZ_EM_FD);
 
   PropagatorExpect pe;
 

--- a/platform/emulator/libfd/sumabs.cc
+++ b/platform/emulator/libfd/sumabs.cc
@@ -31,8 +31,8 @@
 
 OZ_BI_define(fdp_sumAC, 4, 0)
 {
-  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_INT","OZ_EM_VECT OZ_EM_FD","
-		   OZ_EM_LIT","OZ_EM_FD);
+  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_INT "," OZ_EM_VECT OZ_EM_FD ","
+		   OZ_EM_LIT "," OZ_EM_FD);
   
   PropagatorExpect pe;
   OZ_EXPECT(pe, 0, expectVectorInt);

--- a/platform/emulator/libfd/sumd.cc
+++ b/platform/emulator/libfd/sumd.cc
@@ -30,7 +30,7 @@
 
 OZ_BI_define(fdp_dsum, 3, 0)
 {
-  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_FD","OZ_EM_LIT","OZ_EM_FD);
+  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_FD "," OZ_EM_LIT "," OZ_EM_FD);
   
   PropagatorExpect pe;
 
@@ -53,8 +53,8 @@ OZ_BI_end
 
 OZ_BI_define(fdp_dsumC, 4, 0)
 {
-  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_INT","OZ_EM_VECT OZ_EM_FD","OZ_EM_LIT
-		   ","OZ_EM_FD);
+  OZ_EXPECTED_TYPE(OZ_EM_VECT OZ_EM_INT "," OZ_EM_VECT OZ_EM_FD "," OZ_EM_LIT
+		   "," OZ_EM_FD);
 
   PropagatorExpect pe;
 

--- a/platform/emulator/libfset/standard.cc
+++ b/platform/emulator/libfset/standard.cc
@@ -141,7 +141,7 @@ OZ_BI_end
 
 OZ_BI_define(fsp_diff, 3, 0)
 {
-  OZ_EXPECTED_TYPE(OZ_EM_FSET","OZ_EM_FSET","OZ_EM_FSET);
+  OZ_EXPECTED_TYPE(OZ_EM_FSET "," OZ_EM_FSET "," OZ_EM_FSET);
 
   PropagatorExpect pe;
    int susp_count = 0;

--- a/platform/emulator/mozart_cpi.hh
+++ b/platform/emulator/mozart_cpi.hh
@@ -107,8 +107,8 @@
 
 #define OZ_EM_LIT       "literal"
 #define OZ_EM_FLOAT     "float"
-#define OZ_EM_INT       "integer in [~"_OZ_EM_INTMAX"\\,...\\,"_OZ_EM_INTMAX"]"
-#define OZ_EM_FD        "finite domain integer in {"_OZ_EM_FDINF"\\,...\\,"_OZ_EM_FDSUP"}"
+#define OZ_EM_INT       "integer in [~" _OZ_EM_INTMAX "\\,...\\," _OZ_EM_INTMAX "]"
+#define OZ_EM_FD        "finite domain integer in {" _OZ_EM_FDINF "\\,...\\," _OZ_EM_FDSUP "}"
 #define OZ_EM_FDBOOL    "boolean finite domain integer in {0,1}"
 #define OZ_EM_FDDESCR   "description of a finite domain integer"
 #define OZ_EM_FSETVAL   "finite set of integers"

--- a/platform/tools/gump/ozbison/allocate.c
+++ b/platform/tools/gump/ozbison/allocate.c
@@ -19,10 +19,9 @@ the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <mozart.h>
 
-extern char *calloc ();
-extern char *realloc ();
 extern void done ();
 
 char *

--- a/platform/tools/gump/ozbison/conflicts.c
+++ b/platform/tools/gump/ozbison/conflicts.c
@@ -18,6 +18,7 @@ along with Bison; see the file COPYING.  If not, write to
 the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 
 #include <stdio.h>
+#include <string.h>
 #include "system.h"
 #include "machine.h"
 #include "new.h"

--- a/platform/tools/gump/ozbison/print.c
+++ b/platform/tools/gump/ozbison/print.c
@@ -19,6 +19,7 @@ the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 
 
 #include <stdio.h>
+#include <string.h>
 #include "system.h"
 #include "machine.h"
 #include "new.h"

--- a/platform/tools/gump/ozbison/symtab.c
+++ b/platform/tools/gump/ozbison/symtab.c
@@ -19,6 +19,7 @@ the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 
 
 #include <stdio.h>
+#include <string.h>
 #include "system.h"
 #include "new.h"
 #include "symtab.h"


### PR DESCRIPTION
Cherry-picks relevant patches from pull request #195 to remove some compiler warnings from 1.4.x builds.