### PR TITLE
operator 'delete' was used where 'delete[]' was required

### DIFF
--- a/platform/emulator/foreign.cc
+++ b/platform/emulator/foreign.cc
@@ -683,7 +683,7 @@ void float2buffer(ostream &out, OZ_Term term, const char sign)
     }
   }
   if (!hasDot) out << '.' << '0';
-  delete str;
+  delete [] str;
 }
 
 inline

--- a/platform/emulator/hashtbl.hh
+++ b/platform/emulator/hashtbl.hh
@@ -383,7 +383,7 @@ private:
 public:
   GenDistEntryTable(int sizeAsPowerOf2) { init(sizeAsPowerOf2); }
   ~GenDistEntryTable() {
-    delete table;
+    delete [] table;
     DebugCode(table = (NODE **) -1;);
     DebugCode(tableSize = counter = percent = bits = rsBits = -1;);
   }


### PR DESCRIPTION
Operator delete was used where delete[] should have been. This resulted in warnings in valgrind at runtime.