### PR TITLE
operator 'delete' was used where 'delete[]' was required

### DIFF
--- a/platform/emulator/foreign.cc
+++ b/platform/emulator/foreign.cc
@@ -683,7 +683,7 @@ void float2buffer(ostream &out, OZ_Term term, const char sign)
     }
   }
   if (!hasDot) out << '.' << '0';
-  delete str;
+  delete [] str;
 }
 
 inline


### PR DESCRIPTION
Operator delete was used where delete[] should have been. This resulted in warnings in valgrind at runtime. Ported from 1.3.x commit.